### PR TITLE
Make saving new paths more intuitive

### DIFF
--- a/src/mapping_navigation/scripts/MapSerializer.py
+++ b/src/mapping_navigation/scripts/MapSerializer.py
@@ -11,7 +11,7 @@ def save_to_file(map_model: MapModel):
     filename = fd.asksaveasfilename(initialdir=os.path.normpath(os.getcwd() + os.sep + os.pardir)+"/paths",
                                     defaultextension=".pickle",
                                     filetypes=(("Pickle file", "*.pickle"), ("All files", "*.*")),
-                                    title="Select path as...")
+                                    title="Save path as...")
     outfile = open(filename, 'wb')
 
     pickle.dump(map_model, outfile)

--- a/src/mapping_navigation/scripts/MapSerializer.py
+++ b/src/mapping_navigation/scripts/MapSerializer.py
@@ -8,8 +8,10 @@ from typing import Dict, List
 
 # Responsible for saving/loading a road_segments dict to/from a json file
 def save_to_file(map_model: MapModel):
-    filename = fd.askopenfilename(initialdir=os.path.normpath(os.getcwd() + os.sep + os.pardir)+"/paths",
-                                  title="Select file")
+    filename = fd.asksaveasfilename(initialdir=os.path.normpath(os.getcwd() + os.sep + os.pardir)+"/paths",
+                                    defaultextension=".pickle",
+                                    filetypes=(("Pickle file", "*.pickle"), ("All files", "*.*")),
+                                    title="Select path as...")
     outfile = open(filename, 'wb')
 
     pickle.dump(map_model, outfile)


### PR DESCRIPTION
Changed the save coords file dialog to automatically create a new file rather than having to create an empty pickle file before specifying the name in the file dialog.